### PR TITLE
feat: Add Calculators Gallery screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ A cross-platform (web and desktop) Flutter app to streamline radiology workflow 
 - Fonts: Local Roboto fonts (fonts/Roboto/) for offline deployment
 
 **Implemented:**
-- Navigation structure with drawer and routes (/, /design/er, /calc/abdomen, /calc/liver, /calc/tirads, /settings)
+- Navigation structure with drawer and routes (/, /design/er, /calc, /calc/abdomen, /calc/liver, /calc/tirads, /settings)
 - Dynamic AppBar with persistent shell layout
   - Blended gradient AppBar on HomeScreen, inversePrimary on other screens
 - Theme switcher (System/Light/Dark) with SharedPreferencesAsync persistence
@@ -29,6 +29,7 @@ A cross-platform (web and desktop) Flutter app to streamline radiology workflow 
   - Mustache-based template generation (lib/services/design/designer/)
   - Responsive layout with input form and output display
   - Shared UI components (ThreeLevelDropdowns, GenerateButton, CopyButton)
+- Calculators Gallery (/calc): Feature cards grid showcasing calculator screens
 - Calculators: Prostate Volume, Spine Height Loss, Adrenal CT Washout, LIC, TI-RADS
   - Business logic returns data Maps/Records for template rendering
   - Customizable Mustache templates (default + user override)

--- a/lib/app/enums/screen_info.dart
+++ b/lib/app/enums/screen_info.dart
@@ -1,6 +1,7 @@
 /// Screen Information
 enum ScreenInfo {
   designER("Protocol ER"),
+  calcGallery("Calculators"),
   calcAbdo("Abdomen Calculator"),
   calcLiver("Liver Calculator"),
   calcTirads("TI-RADS Calculator");

--- a/lib/app/pages/calculators/calculators_gallery_screen.dart
+++ b/lib/app/pages/calculators/calculators_gallery_screen.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../../router.dart';
+
+/// Gallery screen displaying all available calculator screens as feature cards.
+class CalculatorsGalleryScreen extends StatelessWidget {
+  const CalculatorsGalleryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const _GalleryHeader(),
+          Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 1200),
+              child: const Padding(
+                padding: EdgeInsets.all(24.0),
+                child: _CalculatorCardsGrid(),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GalleryHeader extends StatelessWidget {
+  const _GalleryHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            colorScheme.primaryContainer.withValues(alpha: 0.3),
+            colorScheme.surfaceContainerHighest,
+          ],
+        ),
+      ),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 1200),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    Icons.calculate_outlined,
+                    size: 32,
+                    color: colorScheme.primary,
+                  ),
+                  const SizedBox(width: 12),
+                  Text(
+                    'Calculators',
+                    style: textTheme.headlineMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: colorScheme.onSurface,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Medical calculators and clinical scoring systems for radiology',
+                style: textTheme.bodyLarge?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CalculatorCardData {
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final String route;
+
+  const _CalculatorCardData({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.route,
+  });
+}
+
+class _CalculatorCardsGrid extends StatelessWidget {
+  const _CalculatorCardsGrid();
+
+  @override
+  Widget build(BuildContext context) {
+    const calculators = [
+      _CalculatorCardData(
+        title: 'Abdomen Calculator',
+        subtitle: 'Prostate volume, spine height loss, adrenal CT washout',
+        icon: Icons.accessibility_new_outlined,
+        route: Routes.calculatorAbdomen,
+      ),
+      _CalculatorCardData(
+        title: 'Liver Calculator',
+        subtitle: 'Liver iron concentration (LIC) from MRI T2*',
+        icon: Icons.science_outlined,
+        route: Routes.calculatorLiver,
+      ),
+      _CalculatorCardData(
+        title: 'TI-RADS Calculator',
+        subtitle: 'ACR TI-RADS thyroid nodule assessment',
+        icon: Icons.radar,
+        route: Routes.calculatorTirads,
+      ),
+    ];
+
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+        maxCrossAxisExtent: 350,
+        crossAxisSpacing: 16,
+        mainAxisSpacing: 16,
+        childAspectRatio: 1.3,
+      ),
+      itemCount: calculators.length,
+      itemBuilder: (context, index) {
+        return _CalculatorCard(calculator: calculators[index]);
+      },
+    );
+  }
+}
+
+class _CalculatorCard extends StatelessWidget {
+  final _CalculatorCardData calculator;
+
+  const _CalculatorCard({required this.calculator});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    return Card(
+      elevation: 2,
+      color: colorScheme.surfaceContainerLow,
+      child: InkWell(
+        onTap: () => context.go(calculator.route),
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(20.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                calculator.icon,
+                size: 32,
+                color: colorScheme.primary,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                calculator.title,
+                style: textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                calculator.subtitle,
+                style: textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/pages/home_screen.dart
+++ b/lib/app/pages/home_screen.dart
@@ -221,7 +221,7 @@ class _FeatureCardsGrid extends StatelessWidget {
         title: 'Calculators',
         subtitle: 'Medical calculators and clinical scoring systems',
         icon: Icons.calculate_outlined,
-        route: Routes.calculatorAbdomen,
+        route: Routes.calculatorGallery,
       ),
       _FeatureCardData(
         title: 'Protocols',

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -5,6 +5,7 @@ import 'pages/settings_screen.dart';
 import 'pages/designer/designer_screen.dart';
 import 'pages/calculators/calculator_abdomen_screen.dart';
 import 'pages/calculators/calculator_liver_screen.dart';
+import 'pages/calculators/calculators_gallery_screen.dart';
 import 'pages/calculators/tirads/calculator_tirads_screen.dart';
 import 'pages/settings/calculator_template_editor_screen.dart';
 import 'widgets/shell_layout.dart';
@@ -13,6 +14,7 @@ import 'widgets/shell_layout.dart';
 abstract class Routes {
   static const String home = '/';
   static const String designER = '/design/er';
+  static const String calculatorGallery = '/calc';
   static const String calculatorAbdomen = '/calc/abdomen';
   static const String calculatorLiver = '/calc/liver';
   static const String calculatorTirads = '/calc/tirads';
@@ -40,6 +42,13 @@ final class AppRouter {
             pageBuilder: (context, state) => NoTransitionPage(
               key: state.pageKey,
               child: const DesignERScreen(),
+            ),
+          ),
+          GoRoute(
+            path: Routes.calculatorGallery,
+            pageBuilder: (context, state) => NoTransitionPage(
+              key: state.pageKey,
+              child: const CalculatorsGalleryScreen(),
             ),
           ),
           GoRoute(

--- a/lib/app/widgets/app_drawer.dart
+++ b/lib/app/widgets/app_drawer.dart
@@ -53,6 +53,16 @@ class AppDrawer extends StatelessWidget {
             initiallyExpanded: true,
             children: [
               ListTile(
+                leading: Icon(Icons.grid_view, size: 16),
+                title: Text(ScreenInfo.calcGallery.title),
+                selected: currentLocation == Routes.calculatorGallery,
+                contentPadding: EdgeInsets.only(left: 72),
+                onTap: () {
+                  context.go(Routes.calculatorGallery);
+                  Navigator.pop(context);
+                },
+              ),
+              ListTile(
                 leading: Icon(Icons.circle, size: 12),
                 title: Text(ScreenInfo.calcAbdo.title),
                 selected: currentLocation == Routes.calculatorAbdomen,

--- a/lib/app/widgets/shell_layout.dart
+++ b/lib/app/widgets/shell_layout.dart
@@ -29,9 +29,10 @@ class ShellLayout extends StatelessWidget {
     }
 
     final titleMap = {
-      Routes.designER: ScreenInfo.designER.title, 
+      Routes.designER: ScreenInfo.designER.title,
+      Routes.calculatorGallery: 'Calculators',
       Routes.calculatorAbdomen: 'Abdomen Calculator',
-      Routes.calculatorLiver: "Liver Calculator", 
+      Routes.calculatorLiver: 'Liver Calculator',
       Routes.settings: 'Settings',
     };
 

--- a/lib/app/widgets/version_widget.dart
+++ b/lib/app/widgets/version_widget.dart
@@ -49,6 +49,7 @@ class VersionWidget extends ConsumerWidget {
   void _showVersionDialog(BuildContext context, WidgetRef ref) {
     final String version = AppConfig.appVersion;
     final String shaHash = AppConfig.shaHash;
+    final colorScheme = Theme.of(context).colorScheme;
 
     showDialog(
       context: context,
@@ -62,6 +63,11 @@ class VersionWidget extends ConsumerWidget {
               'Version: $version ($shaHash)',
               style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w500),
             ),
+            SizedBox(height: 16),
+            Text(
+              'Radiology AI Unit © ${DateTime.now().year}',
+              style: TextStyle(fontSize: 12, fontWeight: FontWeight.w400, color: colorScheme.primary),
+            )
           ],
         ),
         actions: [


### PR DESCRIPTION
## Summary
- Add `CalculatorsGalleryScreen` at `/calc` route showcasing all calculator screens with Material 3 feature cards
- Update HomeScreen "Calculators" card to route to gallery instead of Abdomen Calculator
- Add "Calculators" link in drawer navigation (at top of Calculator expansion list)
- Add "Radiology AI Unit" copyright text in version widget

## Test plan
- [ ] Navigate to HomeScreen → click "Calculators" card → should open gallery
- [ ] Verify 3 cards display: Abdomen, Liver, TI-RADS calculators
- [ ] Click each card to verify navigation to correct calculator screen
- [ ] Open drawer → verify "Calculators" link appears and navigates to gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)