### PR TITLE
feat: Protocol CVS + Protocol Ward gallery + shared trailer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ migrate_working_dir/
 *.iws
 .idea/
 
+# Dart DevTools per-developer preferences
+devtools_options.yaml
+
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,85 +2,107 @@
 
 > RadFlow — Streamline Workflow in Radiology
 
-## About
+Cross-platform (web + desktop) Flutter app for radiology calculators, protocol generation, and reporting templates.
 
-A cross-platform (web and desktop) Flutter app to streamline radiology workflow with calculators, protocols, and reporting templates.
+## Tech stack
 
-## Current Status
+| Concern | Choice |
+|---|---|
+| State management | `flutter_riverpod` ^3.0.3 |
+| Routing | `go_router` ^17.0.0 (ShellRoute + persistent AppBar/Drawer) |
+| Persistence | `shared_preferences` ^2.5.3 (`SharedPreferencesAsync`) |
+| Templating | `mustachex` ^1.0.0 |
+| Math rendering | `flutter_math_fork` ^0.7.2 |
+| URL launching | `url_launcher` ^6.3.1 |
+| i18n / dates | `intl` ^0.20.2 |
+| Desktop window | `window_manager` ^0.4.4 |
+| UI | Material 3, custom blue theme (light / dark / contrast variants) |
+| Fonts | Local Roboto family (10 weights + italics, offline) |
 
-- Navigation: `go_router` with `ShellRoute` pattern
-- State management: Riverpod 3.x
-- UI: Material 3 design system
-- Theme: Blue color scheme (lib/app/themes/theme_blue.dart)
-- Fonts: Local Roboto fonts (fonts/Roboto/) for offline deployment
+## Project conventions
 
-**Implemented:**
-- Navigation structure with drawer and routes (/, /design/er, /calc, /calc/abdomen, /calc/liver, /calc/tirads, /settings)
-- Dynamic AppBar with persistent shell layout
-  - Blended gradient AppBar on HomeScreen, inversePrimary on other screens
-- Theme switcher (System/Light/Dark) with SharedPreferencesAsync persistence
-- Custom Material 3 theme with light/dark/contrast variants
-- HomeScreen: Modern Material 3 welcome page
-  - Hero section with gradient background and decorative dots
-  - Responsive feature cards grid (max 350px/card, constrained 1200px container)
-  - Cards link to DesignER, Calculators (with stub placeholders for Protocols, Reports)
-- DesignER Screen: Protocol generator for CT/MRI Emergency Radiology studies
-  - Three-level dropdown selection (Category → Exam → Protocol)
-  - Mustache-based template generation (lib/services/design/designer/)
-  - Responsive layout with input form and output display
-  - Shared UI components (ThreeLevelDropdowns, GenerateButton, CopyButton)
-- Calculators Gallery (/calc): Feature cards grid showcasing calculator screens
-- Calculators: Prostate Volume, Spine Height Loss, Adrenal CT Washout, LIC, TI-RADS
-  - Business logic returns data Maps/Records for template rendering
-  - Customizable Mustache templates (default + user override)
-  - Settings → Calculator Templates editor with live preview
-  - SharedPreferencesAsync persistence for custom templates
-  - Template service with metadata (available variables, sample data)
-  - Type-safe error handling with Result<T, E> pattern (sealed classes)
-  - Specific validation errors displayed via SnackBar (ParseError, ValidationError, CalculationError)
-  - LaTeX formula rendering with clickable citation links (LIC calculator)
-  - TI-RADS: Multi-nodule assessment with real-time TR level preview, size-based FNA recommendations
-- App icons configured via flutter_launcher_icons (web, Windows, macOS)
-- CI/CD: GitHub Actions workflows for web (no CDN), Windows, and macOS builds
+- **Mustache-driven output.** Every generated text artifact (protocol bodies, calculator reports) is rendered from a `.mustache` template against a small data map; assets are declared per directory in `pubspec.yaml`. Default templates ship in `lib/services/<feature>/templates/`; user overrides are stored via `SharedPreferencesAsync`.
+- **Result<T, E> for fallible work.** Calculator business logic returns a sealed `Result` (`lib/core/result.dart`); UI maps the error variant to a SnackBar.
+- **Services vs. screens.** `lib/services/**` is pure Dart — no Flutter imports. `lib/app/**` is the UI layer; widgets compose services and surface I/O.
+- **Two-file feature pages.** Each non-trivial screen is split into `<feature>_screen.dart` (layout + state) and `_<feature>_input.dart` (input form) — see `pages/designer/`, `pages/design_ward/`.
+- **Reusable input atoms.** Cascading dropdowns live in `lib/app/widgets/dropdowns_two.dart` and `dropdowns_three.dart`. The "Check ภาพ + author" trailer used by every Protocol Ward screen lives in `pages/design_ward/_ward_common_input.dart` backed by the `WardCommon` service.
+- **Conventional Commits + GitHub Flow.** Default branch is `main`; feature work on `feat/*` branches via PR.
 
-**Structure:**
+## Routes
+
+| Path | Screen |
+|---|---|
+| `/` | HomeScreen |
+| `/design/er` | DesignERScreen (Protocol ER, 3-level dropdowns + patient fields) |
+| `/design/ward` | DesignWardGalleryScreen (body-part protocol gallery) |
+| `/design/ward/cvs` | DesignCvsScreen (Protocol CVS, 2-level dropdowns + ward-common trailer) |
+| `/calc` | CalculatorsGalleryScreen |
+| `/calc/abdomen` | CalculatorAbdomenScreen (Prostate Volume, Spine Height Loss, Adrenal CT Washout) |
+| `/calc/liver` | CalculatorLiverScreen (LIC from MRI T2*) |
+| `/calc/tirads` | CalculatorTiradsScreen (multi-nodule ACR TI-RADS) |
+| `/settings` | SettingsScreen (theme + persistence) |
+| `/settings/templates/calc` | CalculatorTemplateEditorScreen (full-screen dialog, outside ShellRoute) |
+
+Stub cards in the home grid + ward gallery (e.g. Protocol Chest / Abdomen / MSK) use `route: null` and render as disabled "Soon" tiles — same pattern across the app.
+
+## Feature areas
+
+### Navigation & shell
+- `ShellLayout` provides the persistent AppBar + drawer; AppBar title is route-driven via `titleMap` in `shell_layout.dart`.
+- HomeScreen has a gradient transparent AppBar; other routes use `colorScheme.inversePrimary`.
+- `AppDrawer` groups routes into `ExpansionTile`s ("Design Study", "Calculator"). Add new sub-routes by appending a `ListTile` and updating `ScreenInfo` + `Routes`.
+
+### Design Study
+- **Protocol ER** (`/design/er`) — emergency-radiology CT/MRI generator. 3-level cascade (Category → Exam → Protocol) plus patient-side inputs (NPO, eGFR, premeds, ETT, C1, pregnancy, ref physician). Service: `lib/services/design/designer/`.
+- **Protocol Ward** (`/design/ward`) — gallery for body-part protocols. CVS is the only active member today; Chest / Abdomen / MSK are stubs.
+- **Protocol CVS** (`/design/ward/cvs`) — cardiovascular CTA/MRA generator. 2-level cascade (Exam → Protocol). Service: `lib/services/design/design_cvs/`.
+- **Ward-common trailer** — every Protocol Ward screen appends a shared block: a "Check ภาพ" checkbox gating ก่อน/หลัง IV contrast sub-checkboxes, plus a `Role` dropdown (`ProtocolAuthor`: Resident / Fellow / Staff) + Name + Tel. Pressing Enter in Name/Tel triggers Generate. Widget: `pages/design_ward/_ward_common_input.dart`; service: `lib/services/design/design_ward_common/ward_common.dart`. Future ward screens consume both with two lines of wiring.
+
+### Calculators
+- Each calculator returns a data Map/Record from its service, then renders via a mustache template the user can override in `/settings/templates/calc` (live preview, dashIfBlank-style helpers in `services/design/_utils.dart`).
+- TI-RADS hosts a multi-nodule input UI with real-time TR level preview and size-based FNA recommendations.
+- LIC renders LaTeX formulas via `flutter_math_fork` with clickable citation URLs (`citation_url_launcher.dart`).
+
+### Settings
+- Theme switcher (System / Light / Dark) persisted via `themeProvider` (Riverpod) + `SharedPreferencesAsync`.
+- Calculator template editor screen lives outside the ShellRoute as a full-screen dialog.
+
+### Build & distribution
+- App icons via `flutter_launcher_icons` (web, Windows, macOS).
+- GitHub Actions workflows for web (no-CDN), Windows, and macOS builds. See `Makefile` for local equivalents.
+
+## Layout
+
 ```
 lib/
-├── core/                     # result.dart (Result<T,E> sealed class)
+├── core/                              # result.dart (Result<T,E> sealed class)
 ├── app/
+│   ├── enums/screen_info.dart         # Route → display title enum
 │   ├── pages/
-│   │   ├── designer/         # DesignER screen
-│   │   ├── calculators/      # Calculator UI components + error handler
-│   │   │   └── tirads/       # TI-RADS calculator (multi-nodule input cards)
-│   │   └── settings/         # Calculator template editor
-│   ├── widgets/              # Reusable UI components (buttons, citation_url_launcher)
-│   ├── providers/            # theme_provider, snippet_templates_provider
-│   ├── themes/               # Material 3 theme configurations
+│   │   ├── designer/                  # Protocol ER
+│   │   ├── design_ward/               # Ward gallery + Protocol CVS + shared trailer widget
+│   │   ├── calculators/               # Calculator screens (+ tirads/ subfolder)
+│   │   └── settings/                  # Calculator template editor
+│   ├── providers/                     # theme_provider, snippet_templates_provider
+│   ├── themes/                        # Material 3 light/dark/contrast variants
+│   ├── widgets/                       # Shell, drawer, buttons, dropdowns_two/three, …
 │   └── router.dart
 ├── services/
-│   ├── calculator/           # Calculator business logic + calculator_error.dart
-│   │   ├── shared/           # template_renderer, parser, statistics
-│   │   ├── templates/        # Default Mustache templates
-│   │   └── tirads_calculator/ # TI-RADS business logic (models, validation, data)
-│   ├── design/designer/      # Protocol generation business logic
-│   └── preferences/          # snippet_templates_service
-└── fonts/Roboto/             # Local Roboto font files (offline)
+│   ├── calculator/
+│   │   ├── shared/                    # template_renderer, parser, statistics
+│   │   ├── templates/                 # Default mustache templates
+│   │   └── tirads_calculator/         # TI-RADS business logic
+│   ├── design/
+│   │   ├── _utils.dart                # dashIfBlank, boolYesDash, getCurrentDate
+│   │   ├── enums/                     # Shared design enums (e.g. ProtocolAuthor)
+│   │   ├── designer/                  # Protocol ER service
+│   │   ├── design_cvs/                # Protocol CVS service
+│   │   └── design_ward_common/        # Ward-common trailer service (re-exports ProtocolAuthor)
+│   └── preferences/                   # snippet_templates_service
+└── fonts/Roboto/                      # Local font files
 ```
-
-## Tech Stack
-
-- **State Management:** flutter_riverpod ^3.0.3
-- **Routing:** go_router ^17.0.0
-- **Persistence:** shared_preferences ^2.5.3
-- **UI:** Material 3 with custom blue theme
-- **Fonts:** Local Roboto (10 weights + italic variants)
-- **Templating:** mustachex ^1.0.0
-- **LaTeX Rendering:** flutter_math_fork ^0.7.2
-- **URL Launcher:** url_launcher ^6.3.1
-- **Utils:** intl ^0.20.2
-- **Desktop:** window_manager ^0.4.4
 
 ## Commands
 
-- Use `fvm` to manage Flutter/Dart version in this project. 
-- See @Makefile 
+- Use `fvm` for Flutter/Dart version management.
+- See @Makefile for run / build targets (`run-web-local`, `build-web`, `build-web-local`, `build-web-local-wasm`, `serve-web-local`, `build-web-macos`, `icons`).

--- a/lib/app/enums/screen_info.dart
+++ b/lib/app/enums/screen_info.dart
@@ -1,6 +1,8 @@
 /// Screen Information
 enum ScreenInfo {
   designER("Protocol ER"),
+  designWard("Protocol Ward"),
+  designCvs("Protocol CVS"),
   calcGallery("Calculators"),
   calcAbdo("Abdomen Calculator"),
   calcLiver("Liver Calculator"),

--- a/lib/app/pages/design_ward/_design_cvs_input.dart
+++ b/lib/app/pages/design_ward/_design_cvs_input.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import '../../../services/design/design_cvs/design_cvs_protocol_data.dart';
+import '../../widgets/dropdowns_two.dart';
+
+/// Input form for the Protocol CVS screen.
+///
+/// Currently only hosts the cascading Exam → Protocol dropdowns. Kept as a
+/// separate widget (mirroring `DesignERInput`) so additional fields can be
+/// dropped in later without restructuring the screen.
+class DesignCvsInput extends StatefulWidget {
+  /// Emits the selected `protocolId` (or `null` when the protocol level is
+  /// not yet chosen).
+  final void Function(String? protocolId) onSelectionChanged;
+
+  const DesignCvsInput({
+    super.key,
+    required this.onSelectionChanged,
+  });
+
+  @override
+  State<DesignCvsInput> createState() => DesignCvsInputState();
+}
+
+class DesignCvsInputState extends State<DesignCvsInput> {
+  final GlobalKey<TwoLevelDropdownsState> _dropdownsKey =
+      GlobalKey<TwoLevelDropdownsState>();
+
+  /// Resets both dropdowns and re-emits `null` to the parent.
+  void reset() {
+    _dropdownsKey.currentState?.reset();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TwoLevelDropdowns(
+      key: _dropdownsKey,
+      choiceIdMap: DesignCvsProtocolData.choiceIdMap,
+      idDispMap: DesignCvsProtocolData.idDispMap,
+      onSelectionChanged: (selectionMap) {
+        widget.onSelectionChanged(selectionMap['level2']);
+      },
+    );
+  }
+}

--- a/lib/app/pages/design_ward/_design_cvs_input.dart
+++ b/lib/app/pages/design_ward/_design_cvs_input.dart
@@ -1,20 +1,25 @@
 import 'package:flutter/material.dart';
 import '../../../services/design/design_cvs/design_cvs_protocol_data.dart';
+import '../../../services/design/design_ward_common/ward_common.dart';
 import '../../widgets/dropdowns_two.dart';
+import '_ward_common_input.dart';
 
-/// Input form for the Protocol CVS screen.
+/// Aggregate input form for the Protocol CVS screen.
 ///
-/// Currently only hosts the cascading Exam → Protocol dropdowns. Kept as a
-/// separate widget (mirroring `DesignERInput`) so additional fields can be
-/// dropped in later without restructuring the screen.
+/// Composes the protocol selector (cascading Exam → Protocol dropdowns)
+/// with the ward-common block (Check ภาพ + Resident). The screen receives
+/// a single combined snapshot via [onSelectionChanged].
 class DesignCvsInput extends StatefulWidget {
-  /// Emits the selected `protocolId` (or `null` when the protocol level is
-  /// not yet chosen).
-  final void Function(String? protocolId) onSelectionChanged;
+  final void Function(DesignCvsInputValues values) onSelectionChanged;
+
+  /// Fires when the user submits a text field via Enter. The screen wires
+  /// this to its Generate action.
+  final VoidCallback? onSubmit;
 
   const DesignCvsInput({
     super.key,
     required this.onSelectionChanged,
+    this.onSubmit,
   });
 
   @override
@@ -24,21 +29,60 @@ class DesignCvsInput extends StatefulWidget {
 class DesignCvsInputState extends State<DesignCvsInput> {
   final GlobalKey<TwoLevelDropdownsState> _dropdownsKey =
       GlobalKey<TwoLevelDropdownsState>();
+  final GlobalKey<WardCommonInputState> _wardCommonKey =
+      GlobalKey<WardCommonInputState>();
 
-  /// Resets both dropdowns and re-emits `null` to the parent.
+  String? _protocolId;
+  WardCommonValues _wardCommon = const WardCommonValues.empty();
+
+  /// Resets both child widgets back to their initial state.
   void reset() {
     _dropdownsKey.currentState?.reset();
+    _wardCommonKey.currentState?.reset();
+  }
+
+  void _emit() {
+    widget.onSelectionChanged(DesignCvsInputValues(
+      protocolId: _protocolId,
+      wardCommon: _wardCommon,
+    ));
   }
 
   @override
   Widget build(BuildContext context) {
-    return TwoLevelDropdowns(
-      key: _dropdownsKey,
-      choiceIdMap: DesignCvsProtocolData.choiceIdMap,
-      idDispMap: DesignCvsProtocolData.idDispMap,
-      onSelectionChanged: (selectionMap) {
-        widget.onSelectionChanged(selectionMap['level2']);
-      },
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TwoLevelDropdowns(
+          key: _dropdownsKey,
+          choiceIdMap: DesignCvsProtocolData.choiceIdMap,
+          idDispMap: DesignCvsProtocolData.idDispMap,
+          onSelectionChanged: (selectionMap) {
+            _protocolId = selectionMap['level2'];
+            _emit();
+          },
+        ),
+        const SizedBox(height: 16),
+        WardCommonInput(
+          key: _wardCommonKey,
+          onChanged: (values) {
+            _wardCommon = values;
+            _emit();
+          },
+          onSubmit: widget.onSubmit,
+        ),
+      ],
     );
   }
+}
+
+/// Combined snapshot emitted to the parent screen.
+class DesignCvsInputValues {
+  final String? protocolId;
+  final WardCommonValues wardCommon;
+
+  const DesignCvsInputValues({
+    required this.protocolId,
+    required this.wardCommon,
+  });
 }

--- a/lib/app/pages/design_ward/_ward_common_input.dart
+++ b/lib/app/pages/design_ward/_ward_common_input.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import '../../../services/design/design_ward_common/ward_common.dart';
+
+/// Reusable input block for Protocol Ward screens: a "Check ภาพ" checkbox
+/// gating two phase sub-checkboxes (ก่อน / หลัง IV contrast), plus the
+/// Resident Name and Tel fields.
+///
+/// State stays internal and is emitted as a fresh [WardCommonValues] on
+/// every change. Toggling `Check ภาพ` off clears and disables the two
+/// sub-checkboxes so the rendered output cannot reach an ambiguous state.
+class WardCommonInput extends StatefulWidget {
+  final void Function(WardCommonValues values) onChanged;
+
+  /// Fires when the user presses Enter inside Name or Tel. Screens wire this
+  /// to their Generate action so a keyboard-driven flow doesn't require a
+  /// mouse click after typing.
+  final VoidCallback? onSubmit;
+
+  const WardCommonInput({
+    super.key,
+    required this.onChanged,
+    this.onSubmit,
+  });
+
+  @override
+  State<WardCommonInput> createState() => WardCommonInputState();
+}
+
+class WardCommonInputState extends State<WardCommonInput> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _telController = TextEditingController();
+
+  bool _checkImage = false;
+  bool _beforeIv = false;
+  bool _afterIv = false;
+  ProtocolAuthor _author = ProtocolAuthor.resident;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _telController.dispose();
+    super.dispose();
+  }
+
+  /// Clears every field and re-emits the empty value.
+  void reset() {
+    setState(() {
+      _checkImage = false;
+      _beforeIv = false;
+      _afterIv = false;
+      _author = ProtocolAuthor.resident;
+      _nameController.clear();
+      _telController.clear();
+    });
+    _emit();
+  }
+
+  void _emit() {
+    widget.onChanged(WardCommonValues(
+      checkImage: _checkImage,
+      beforeIv: _beforeIv,
+      afterIv: _afterIv,
+      author: _author,
+      authorName: _nameController.text,
+      authorTel: _telController.text,
+    ));
+  }
+
+  void _onCheckImageChanged(bool? value) {
+    setState(() {
+      _checkImage = value ?? false;
+      if (!_checkImage) {
+        // Sub-checkboxes don't carry meaning without the parent.
+        _beforeIv = false;
+        _afterIv = false;
+      }
+    });
+    _emit();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildCheckboxRow(),
+        const SizedBox(height: 16),
+        _buildTextFieldsRow(),
+      ],
+    );
+  }
+
+  Widget _buildCheckboxRow() {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: _CheckboxTile(
+            label: 'Check ภาพ',
+            value: _checkImage,
+            onChanged: _onCheckImageChanged,
+          ),
+        ),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _CheckboxTile(
+                label: 'ก่อน IV contrast',
+                value: _beforeIv,
+                enabled: _checkImage,
+                onChanged: (v) {
+                  setState(() => _beforeIv = v ?? false);
+                  _emit();
+                },
+              ),
+              const SizedBox(height: 8),
+              _CheckboxTile(
+                label: 'หลัง IV contrast',
+                value: _afterIv,
+                enabled: _checkImage,
+                onChanged: (v) {
+                  setState(() => _afterIv = v ?? false);
+                  _emit();
+                },
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTextFieldsRow() {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Expanded(
+          flex: 1,
+          child: DropdownMenu<ProtocolAuthor>(
+            initialSelection: _author,
+            expandedInsets: EdgeInsets.zero,
+            label: const Text('Role'),
+            onSelected: (value) {
+              if (value == null) return;
+              setState(() => _author = value);
+              _emit();
+            },
+            dropdownMenuEntries: ProtocolAuthor.values
+                .map((role) => DropdownMenuEntry<ProtocolAuthor>(
+                      value: role,
+                      label: role.label,
+                    ))
+                .toList(),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          flex: 2,
+          child: TextField(
+            controller: _nameController,
+            textInputAction: TextInputAction.next,
+            decoration: const InputDecoration(
+              labelText: 'Name',
+              hintText: 'Name',
+              border: OutlineInputBorder(),
+            ),
+            onChanged: (_) => _emit(),
+            onSubmitted: (_) => widget.onSubmit?.call(),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          flex: 1,
+          child: TextField(
+            controller: _telController,
+            textInputAction: TextInputAction.done,
+            decoration: const InputDecoration(
+              labelText: 'Tel.',
+              hintText: 'Tel.',
+              border: OutlineInputBorder(),
+            ),
+            onChanged: (_) => _emit(),
+            onSubmitted: (_) => widget.onSubmit?.call(),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CheckboxTile extends StatelessWidget {
+  final String label;
+  final bool value;
+  final bool enabled;
+  final ValueChanged<bool?> onChanged;
+
+  const _CheckboxTile({
+    required this.label,
+    required this.value,
+    required this.onChanged,
+    this.enabled = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final disabledColor = Theme.of(context).disabledColor;
+    return Row(
+      children: [
+        CupertinoCheckbox(
+          value: value,
+          onChanged: enabled ? onChanged : null,
+        ),
+        const SizedBox(width: 8),
+        Text(
+          label,
+          style: enabled ? null : TextStyle(color: disabledColor),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/app/pages/design_ward/design_cvs_screen.dart
+++ b/lib/app/pages/design_ward/design_cvs_screen.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import '../../../services/design/design_cvs/design_cvs.dart';
+import '../../widgets/buttons.dart';
+import '_design_cvs_input.dart';
+
+/// Protocol CVS screen — generates cardiovascular CT/MR study protocols.
+///
+/// Mirrors `DesignERScreen` but simpler: only a 2-level Exam → Protocol
+/// selector drives generation; no patient-side input fields yet.
+class DesignCvsScreen extends StatefulWidget {
+  const DesignCvsScreen({super.key});
+
+  @override
+  State<DesignCvsScreen> createState() => _DesignCvsScreenState();
+}
+
+class _DesignCvsScreenState extends State<DesignCvsScreen> {
+  final GlobalKey<DesignCvsInputState> _inputKey =
+      GlobalKey<DesignCvsInputState>();
+  final TextEditingController _outputController = TextEditingController();
+
+  String? _protocolId;
+
+  bool get _isSelectionComplete => _protocolId != null;
+
+  @override
+  void dispose() {
+    _outputController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _generateProtocol() async {
+    if (!_isSelectionComplete) {
+      _showSnackBar('Please select a protocol first');
+      return;
+    }
+
+    try {
+      final cvs = DesignCvs(protocolId: _protocolId!);
+      final template = await cvs.generate();
+      setState(() {
+        _outputController.text = template;
+      });
+    } catch (e) {
+      _showSnackBar('Error generating protocol: $e');
+    }
+  }
+
+  void _resetInputs() {
+    _inputKey.currentState?.reset();
+    setState(() {
+      _outputController.clear();
+      _protocolId = null;
+    });
+  }
+
+  void _showSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth > 800) {
+          return _buildDesktopLayout();
+        }
+        return _buildMobileLayout();
+      },
+    );
+  }
+
+  Widget _buildDesktopLayout() {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(flex: 1, child: _buildInputCard()),
+          const SizedBox(width: 16),
+          Expanded(flex: 1, child: _buildOutputSection()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMobileLayout() {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildInputCard(),
+          const SizedBox(height: 16),
+          _buildOutputSection(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInputCard() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: DesignCvsInput(
+          key: _inputKey,
+          onSelectionChanged: (protocolId) {
+            setState(() {
+              _protocolId = protocolId;
+            });
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildOutputSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: TextField(
+              controller: _outputController,
+              maxLines: 23,
+              readOnly: false,
+              decoration: InputDecoration(
+                border: const OutlineInputBorder(),
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(
+                    color: Theme.of(context).colorScheme.tertiary,
+                  ),
+                ),
+                hintText: 'Generated protocol will appear here...',
+              ),
+              style: const TextStyle(
+                fontFamily: 'monospace',
+                fontSize: 14,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Row(
+              children: [
+                GenerateButton(
+                  onPressed: _isSelectionComplete ? _generateProtocol : null,
+                ),
+                const SizedBox(width: 8),
+                CopyButton(controller: _outputController),
+              ],
+            ),
+            ElevatedButton.icon(
+              onPressed: _resetInputs,
+              icon: const Icon(Icons.refresh),
+              label: const Text('Reset'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/app/pages/design_ward/design_cvs_screen.dart
+++ b/lib/app/pages/design_ward/design_cvs_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../services/design/design_cvs/design_cvs.dart';
+import '../../../services/design/design_ward_common/ward_common.dart';
 import '../../widgets/buttons.dart';
 import '_design_cvs_input.dart';
 
@@ -20,6 +21,7 @@ class _DesignCvsScreenState extends State<DesignCvsScreen> {
   final TextEditingController _outputController = TextEditingController();
 
   String? _protocolId;
+  WardCommonValues _wardCommon = const WardCommonValues.empty();
 
   bool get _isSelectionComplete => _protocolId != null;
 
@@ -36,10 +38,11 @@ class _DesignCvsScreenState extends State<DesignCvsScreen> {
     }
 
     try {
-      final cvs = DesignCvs(protocolId: _protocolId!);
-      final template = await cvs.generate();
+      final body = await DesignCvs(protocolId: _protocolId!).generate();
+      final trailer = const WardCommon().append(_wardCommon);
+      final output = trailer.isEmpty ? body : '$body\n$trailer';
       setState(() {
-        _outputController.text = template;
+        _outputController.text = output;
       });
     } catch (e) {
       _showSnackBar('Error generating protocol: $e');
@@ -51,6 +54,7 @@ class _DesignCvsScreenState extends State<DesignCvsScreen> {
     setState(() {
       _outputController.clear();
       _protocolId = null;
+      _wardCommon = const WardCommonValues.empty();
     });
   }
 
@@ -106,10 +110,14 @@ class _DesignCvsScreenState extends State<DesignCvsScreen> {
         padding: const EdgeInsets.all(16.0),
         child: DesignCvsInput(
           key: _inputKey,
-          onSelectionChanged: (protocolId) {
+          onSelectionChanged: (values) {
             setState(() {
-              _protocolId = protocolId;
+              _protocolId = values.protocolId;
+              _wardCommon = values.wardCommon;
             });
+          },
+          onSubmit: () {
+            if (_isSelectionComplete) _generateProtocol();
           },
         ),
       ),

--- a/lib/app/pages/design_ward/design_ward_gallery_screen.dart
+++ b/lib/app/pages/design_ward/design_ward_gallery_screen.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../../router.dart';
+
+/// Gallery screen listing body-part-specific ward protocols.
+///
+/// Only Protocol CVS is wired today; Chest / Abdomen / MSK render as disabled
+/// stubs (no `route`) following the same convention as the home-screen
+/// feature grid.
+class DesignWardGalleryScreen extends StatelessWidget {
+  const DesignWardGalleryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const _GalleryHeader(),
+          Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 1200),
+              child: const Padding(
+                padding: EdgeInsets.all(24.0),
+                child: _ProtocolCardsGrid(),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GalleryHeader extends StatelessWidget {
+  const _GalleryHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            colorScheme.primaryContainer.withValues(alpha: 0.3),
+            colorScheme.surfaceContainerHighest,
+          ],
+        ),
+      ),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 1200),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    Icons.local_hospital_outlined,
+                    size: 32,
+                    color: colorScheme.primary,
+                  ),
+                  const SizedBox(width: 12),
+                  Text(
+                    'Protocol Ward',
+                    style: textTheme.headlineMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: colorScheme.onSurface,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Body-part-specific CT and MR protocols for ward studies',
+                style: textTheme.bodyLarge?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ProtocolCardData {
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final String? route;
+
+  const _ProtocolCardData({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.route,
+  });
+}
+
+class _ProtocolCardsGrid extends StatelessWidget {
+  const _ProtocolCardsGrid();
+
+  @override
+  Widget build(BuildContext context) {
+    const protocols = [
+      _ProtocolCardData(
+        title: 'Protocol CVS',
+        subtitle: 'Cardiovascular CTA and MRA protocols',
+        icon: Icons.favorite_outline,
+        route: Routes.designCvs,
+      ),
+      _ProtocolCardData(
+        title: 'Protocol Chest',
+        subtitle: 'Thoracic CT and MR protocols',
+        icon: Icons.air_outlined,
+        route: null,
+      ),
+      _ProtocolCardData(
+        title: 'Protocol Abdomen',
+        subtitle: 'Abdominopelvic CT and MR protocols',
+        icon: Icons.accessibility_new_outlined,
+        route: null,
+      ),
+      _ProtocolCardData(
+        title: 'Protocol MSK',
+        subtitle: 'Musculoskeletal CT and MR protocols',
+        icon: Icons.fitness_center_outlined,
+        route: null,
+      ),
+    ];
+
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+        maxCrossAxisExtent: 350,
+        crossAxisSpacing: 16,
+        mainAxisSpacing: 16,
+        childAspectRatio: 1.3,
+      ),
+      itemCount: protocols.length,
+      itemBuilder: (context, index) {
+        return _ProtocolCard(protocol: protocols[index]);
+      },
+    );
+  }
+}
+
+class _ProtocolCard extends StatelessWidget {
+  final _ProtocolCardData protocol;
+
+  const _ProtocolCard({required this.protocol});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+    final isEnabled = protocol.route != null;
+
+    return Card(
+      elevation: 2,
+      color: colorScheme.surfaceContainerLow,
+      child: InkWell(
+        onTap: isEnabled ? () => context.go(protocol.route!) : null,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(20.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                protocol.icon,
+                size: 32,
+                color: isEnabled
+                    ? colorScheme.primary
+                    : colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      protocol.title,
+                      style: textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: isEnabled
+                            ? colorScheme.onSurface
+                            : colorScheme.onSurfaceVariant
+                                .withValues(alpha: 0.6),
+                      ),
+                    ),
+                  ),
+                  if (!isEnabled)
+                    Text(
+                      'Soon',
+                      style: textTheme.labelSmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant
+                            .withValues(alpha: 0.7),
+                      ),
+                    ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                protocol.subtitle,
+                style: textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant
+                      .withValues(alpha: isEnabled ? 1.0 : 0.6),
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/pages/home_screen.dart
+++ b/lib/app/pages/home_screen.dart
@@ -218,16 +218,16 @@ class _FeatureCardsGrid extends StatelessWidget {
         route: Routes.designER,
       ),
       _FeatureCardData(
+        title: ScreenInfo.designWard.title,
+        subtitle: 'Generate CT/MRI protocols for Ward studies (CVS, Chest, Abdo, MSK, Neuro)',
+        icon: Icons.local_hospital_outlined,
+        route: Routes.designWard,
+      ),
+      _FeatureCardData(
         title: 'Calculators',
         subtitle: 'Medical calculators and clinical scoring systems',
         icon: Icons.calculate_outlined,
         route: Routes.calculatorGallery,
-      ),
-      _FeatureCardData(
-        title: 'Protocols',
-        subtitle: 'Imaging protocols and departmental guidelines',
-        icon: Icons.description_outlined,
-        route: null, // Stub - not implemented yet
       ),
       // _FeatureCardData(
       //   title: 'Reports',

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -3,6 +3,8 @@ import 'package:go_router/go_router.dart';
 import 'pages/home_screen.dart';
 import 'pages/settings_screen.dart';
 import 'pages/designer/designer_screen.dart';
+import 'pages/design_ward/design_ward_gallery_screen.dart';
+import 'pages/design_ward/design_cvs_screen.dart';
 import 'pages/calculators/calculator_abdomen_screen.dart';
 import 'pages/calculators/calculator_liver_screen.dart';
 import 'pages/calculators/calculators_gallery_screen.dart';
@@ -14,6 +16,8 @@ import 'widgets/shell_layout.dart';
 abstract class Routes {
   static const String home = '/';
   static const String designER = '/design/er';
+  static const String designWard = '/design/ward';
+  static const String designCvs = '/design/ward/cvs';
   static const String calculatorGallery = '/calc';
   static const String calculatorAbdomen = '/calc/abdomen';
   static const String calculatorLiver = '/calc/liver';
@@ -42,6 +46,20 @@ final class AppRouter {
             pageBuilder: (context, state) => NoTransitionPage(
               key: state.pageKey,
               child: const DesignERScreen(),
+            ),
+          ),
+          GoRoute(
+            path: Routes.designWard,
+            pageBuilder: (context, state) => NoTransitionPage(
+              key: state.pageKey,
+              child: const DesignWardGalleryScreen(),
+            ),
+          ),
+          GoRoute(
+            path: Routes.designCvs,
+            pageBuilder: (context, state) => NoTransitionPage(
+              key: state.pageKey,
+              child: const DesignCvsScreen(),
             ),
           ),
           GoRoute(

--- a/lib/app/widgets/app_drawer.dart
+++ b/lib/app/widgets/app_drawer.dart
@@ -38,10 +38,30 @@ class AppDrawer extends StatelessWidget {
               ListTile(
                 leading: Icon(Icons.circle, size: 12),
                 title: Text(ScreenInfo.designER.title),
-                selected: currentLocation == '/design/er',
+                selected: currentLocation == Routes.designER,
                 contentPadding: EdgeInsets.only(left: 72),
                 onTap: () {
-                  context.go('/design/er');
+                  context.go(Routes.designER);
+                  Navigator.pop(context);
+                },
+              ),
+              ListTile(
+                leading: Icon(Icons.grid_view, size: 16),
+                title: Text(ScreenInfo.designWard.title),
+                selected: currentLocation == Routes.designWard,
+                contentPadding: EdgeInsets.only(left: 72),
+                onTap: () {
+                  context.go(Routes.designWard);
+                  Navigator.pop(context);
+                },
+              ),
+              ListTile(
+                leading: Icon(Icons.circle, size: 12),
+                title: Text(ScreenInfo.designCvs.title),
+                selected: currentLocation == Routes.designCvs,
+                contentPadding: EdgeInsets.only(left: 72),
+                onTap: () {
+                  context.go(Routes.designCvs);
                   Navigator.pop(context);
                 },
               ),

--- a/lib/app/widgets/dropdowns_two.dart
+++ b/lib/app/widgets/dropdowns_two.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+
+/// A clean, focused two-level dependent dropdown component.
+///
+/// Sibling of [ThreeLevelDropdowns] for cases where only two cascading
+/// selections are needed (e.g. Exam → Protocol). Same callback contract,
+/// same cascading-reset semantics — changing level 1 clears level 2.
+class TwoLevelDropdowns extends StatefulWidget {
+  /// Hierarchical choice structure using internal IDs:
+  /// `level1Id -> List<level2Id>`.
+  final Map<String, List<String>> choiceIdMap;
+
+  /// Mapping from internal IDs to user-visible display names.
+  final Map<String, String> idDispMap;
+
+  /// Labels for each dropdown level (optional).
+  final String? level1Label;
+  final String? level2Label;
+
+  /// Hint texts for each dropdown (optional).
+  final String? level1Hint;
+  final String? level2Hint;
+
+  /// Selection callback. Emits `{'level1': id, 'level2': id}` with either
+  /// value possibly `null` when not yet chosen.
+  final Function(Map<String, String?>) onSelectionChanged;
+
+  const TwoLevelDropdowns({
+    super.key,
+    required this.choiceIdMap,
+    required this.idDispMap,
+    this.level1Label,
+    this.level2Label,
+    this.level1Hint,
+    this.level2Hint,
+    required this.onSelectionChanged,
+  });
+
+  @override
+  State<TwoLevelDropdowns> createState() => TwoLevelDropdownsState();
+}
+
+class TwoLevelDropdownsState extends State<TwoLevelDropdowns> {
+  String? _selectedLevel1Id;
+  String? _selectedLevel2Id;
+
+  List<String> get _availableLevel2Ids {
+    if (_selectedLevel1Id == null) return [];
+    return widget.choiceIdMap[_selectedLevel1Id!] ?? [];
+  }
+
+  void _onLevel1Changed(String? newLevel1Id) {
+    setState(() {
+      _selectedLevel1Id = newLevel1Id;
+      _selectedLevel2Id = null;
+    });
+    _notifySelectionChanged();
+  }
+
+  void _onLevel2Changed(String? newLevel2Id) {
+    setState(() {
+      _selectedLevel2Id = newLevel2Id;
+    });
+    _notifySelectionChanged();
+  }
+
+  /// Resets both levels and notifies the parent. Public so screens can drive
+  /// reset via a `GlobalKey<TwoLevelDropdownsState>`.
+  void reset() {
+    setState(() {
+      _selectedLevel1Id = null;
+      _selectedLevel2Id = null;
+    });
+    _notifySelectionChanged();
+  }
+
+  void _notifySelectionChanged() {
+    widget.onSelectionChanged({
+      'level1': _selectedLevel1Id,
+      'level2': _selectedLevel2Id,
+    });
+  }
+
+  String _getDisplayName(String id) {
+    return widget.idDispMap[id] ?? id;
+  }
+
+  List<DropdownMenuEntry<String>> _buildMenuEntries(List<String> ids) {
+    return ids
+        .map((String id) => DropdownMenuEntry<String>(
+              value: id,
+              label: _getDisplayName(id),
+            ))
+        .toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildDropdownSection(
+          title: widget.level1Label,
+          subtitle: widget.level1Label != null
+              ? 'Choose your ${widget.level1Label!.toLowerCase()}'
+              : null,
+          hintText: widget.level1Hint ?? 'Exam',
+          value: _selectedLevel1Id,
+          items: widget.choiceIdMap.keys.toList(),
+          onChanged: _onLevel1Changed,
+          isEnabled: true,
+        ),
+        const SizedBox(height: 20),
+        _buildDropdownSection(
+          title: widget.level2Label,
+          subtitle: null,
+          hintText: widget.level2Hint ?? 'Protocol',
+          value: _selectedLevel2Id,
+          items: _availableLevel2Ids,
+          onChanged: _onLevel2Changed,
+          isEnabled: _selectedLevel1Id != null,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDropdownSection({
+    required String? title,
+    required String? subtitle,
+    required String hintText,
+    required String? value,
+    required List<String> items,
+    required ValueChanged<String?> onChanged,
+    required bool isEnabled,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (title != null) ...[
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 4),
+        ],
+        if (subtitle != null) ...[
+          Text(
+            subtitle,
+            style: TextStyle(
+              fontSize: 14,
+              color: isEnabled ? Colors.grey.shade600 : Colors.grey.shade400,
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+        DropdownMenu<String>(
+          width: MediaQuery.of(context).size.width * 0.5,
+          hintText: hintText,
+          onSelected: isEnabled ? onChanged : null,
+          enabled: isEnabled,
+          label: Text(hintText),
+          dropdownMenuEntries: _buildMenuEntries(items),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/app/widgets/shell_layout.dart
+++ b/lib/app/widgets/shell_layout.dart
@@ -30,6 +30,8 @@ class ShellLayout extends StatelessWidget {
 
     final titleMap = {
       Routes.designER: ScreenInfo.designER.title,
+      Routes.designWard: ScreenInfo.designWard.title,
+      Routes.designCvs: ScreenInfo.designCvs.title,
       Routes.calculatorGallery: 'Calculators',
       Routes.calculatorAbdomen: 'Abdomen Calculator',
       Routes.calculatorLiver: 'Liver Calculator',

--- a/lib/services/design/design_cvs/design_cvs.dart
+++ b/lib/services/design/design_cvs/design_cvs.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:mustachex/mustachex.dart';
+import 'design_cvs_protocol_data.dart';
+
+/// Generates cardiovascular (CTA / MRA) study protocol templates.
+///
+/// Looks up a protocol by [protocolId] in [DesignCvsProtocolData.protocolInfo]
+/// and renders the shared mustache template
+/// (`lib/services/design/design_cvs/template/temp_cvs.mustache`).
+///
+/// Unlike the emergency-radiology [Designer], CVS protocols do not collect
+/// patient-side parameters (NPO, eGFR, premedications, etc.) — the rendered
+/// output is fully determined by the static protocol data.
+///
+/// Example:
+/// ```dart
+/// final cvs = DesignCvs(protocolId: 'cta_coro');
+/// final text = await cvs.generate();
+/// ```
+class DesignCvs {
+  /// Protocol identifier; must be a key of
+  /// [DesignCvsProtocolData.protocolInfo].
+  final String protocolId;
+
+  DesignCvs({
+    required this.protocolId,
+  });
+
+  /// Renders the protocol template as a single string.
+  ///
+  /// Throws an [Exception] if [protocolId] is not registered in
+  /// [DesignCvsProtocolData.protocolInfo], or if the mustache asset cannot be
+  /// loaded (e.g. its directory is not declared in `pubspec.yaml`).
+  Future<String> generate() async {
+    return await designCvsStudy();
+  }
+
+  /// Resolves the protocol entry and renders the CVS mustache template.
+  ///
+  /// Kept separate from [generate] to leave room for future per-modality
+  /// branches (e.g. a dedicated MRA template) without changing callers.
+  Future<String> designCvsStudy() async {
+    final protocolInfo = DesignCvsProtocolData.protocolInfo[protocolId];
+    if (protocolInfo == null) {
+      throw Exception('Protocol ID not found: $protocolId');
+    }
+
+    final templateString = await rootBundle.loadString(
+      'lib/services/design/design_cvs/template/temp_cvs.mustache',
+    );
+    final template = Template(templateString, htmlEscapeValues: false);
+
+    final data = _prepareCvsData(protocolInfo);
+    return template.renderString(data);
+  }
+
+  /// Builds the mustache context map from a protocol entry.
+  ///
+  /// Trims `phaseDesignText`, `contrastText`, and `note` so the triple-quoted
+  /// source blocks in [DesignCvsProtocolData] (which start and end with `\n`
+  /// for readability) don't introduce blank lines under their section headers
+  /// in the rendered output. Missing optional fields stay `null`, which
+  /// mustache treats as falsy and omits the surrounding section.
+  Map<String, dynamic> _prepareCvsData(Map<String, Object?> protocolInfo) {
+    final protocolName = protocolInfo['protocolName'];
+    final phaseDesignText = (protocolInfo['phaseDesignText'] as String?)?.trim();
+    final contrastText = (protocolInfo['contrastText'] as String?)?.trim();
+    final note = (protocolInfo['note'] as String?)?.trim();
+
+    return <String, dynamic>{
+      'protocolName': protocolName,
+      'phaseDesignText': phaseDesignText,
+      'contrastText': contrastText,
+      'note': note,
+    };
+  }
+}

--- a/lib/services/design/design_cvs/design_cvs_protocol_data.dart
+++ b/lib/services/design/design_cvs/design_cvs_protocol_data.dart
@@ -1,0 +1,162 @@
+// ===== DATA MODULE for Design CTA & MRA for Cardiovascular Study =====
+
+class DesignCvsProtocolData {
+  // ID-based hierarchical mapping from: `exam_id` -> `protocol_id` (2 level dependent dropdown)
+  // These will appear in the app dropdown level 1 and 2 respectively. 
+  static const Map<String, List<String>> choiceIdMap = {
+    "ct": [
+      "ct_calcium",
+      "cta_coro",
+      "cta_cardiac_mass",
+      "cta_aortic_dissect",
+      "cta_ruptured_aortic_aneu",
+      "cta_pe",
+      "cta_tavr_preop",
+      "cta_tevar_evar_follow"
+    ],
+    "mri": [
+      "mra_tra_ste_trv_thrombo"
+    ]
+  };
+
+  // ID to Display name mapping (what users see in the dropdown)
+  static const Map<String, String> idDispMap = {
+    // Exam: `exam_id` -> `exam_name`
+    "ct": "CT",
+    "mri": "MRI",
+    // Protocol: `protocol_id` -> `protocol_name`
+    "ct_calcium": "CT Screening Coronary (CAC)",
+    "cta_coro": "CTA Coronary (CAD)",
+    "cta_cardiac_mass": "CTA Cardiac Mass",
+    "cta_aortic_dissect": "CTA Aortic Dissection",
+    "cta_ruptured_aortic_aneu": "CTA Rupture Aortic Aneurysm",
+    "cta_pe": "CTA for PE",
+    "cta_tavr_preop": "CTA Whole Aorta (pre-op TAVR)",
+    "cta_tevar_evar_follow": "CTA Whole Aorta (TEVAR/EVAR)",
+    "mra_tra_ste_trv_thrombo": "MRA for TRA Stenosis / TRV Thrombosis"
+  };
+
+  // Protocol Information
+  static final Map<String, Map<String, Object?>> protocolInfo = {
+    // CT Screening Coronary (CAC)
+    "ct_calcium": {
+      'protocolName': idDispMap['ct_calcium']!,
+      'contrastText': "non-contrast",
+      'phaseDesignText': '''
+- Prospective ECG-gated CT covers the heart
+''',
+      'note': null
+    },
+    // CTA Coronary (CAD)
+    "cta_coro": {
+      'protocolName': idDispMap['cta_coro']!,
+      'contrastText': '''
+- IV contrast 50-100 ml at right antecubital fossa, flow rate 5 ml/sec
+''',
+      'phaseDesignText': '''
+- Coronary artery calcium scoring
+- ECG-gated CTA covers the heart
+- Venous (chest)
+''',
+      'note': '''
+Patient with CABG -> scan cover from the **thoracic inlet to the base of heart**
+'''
+    },
+    // CTA Cardiac Mass
+    "cta_cardiac_mass": {
+      'protocolName': idDispMap['cta_cardiac_mass']!,
+      'contrastText': '''
+- IV contrast 60-100 ml at right antecubital fossa, flow rate 5 ml/sec
+''',
+      'phaseDesignText': '''
+- Pre-contrast: prospective ECG-gated CT covers the heart
+- ECG-gated CTA covers the heart
+- Delayed or venous phase (chest and cardiac mass)
+''',
+      'note': null
+    },
+    // CTA Aortic Dissection
+    "cta_aortic_dissect": {
+      'protocolName': idDispMap['cta_aortic_dissect']!,
+      'contrastText': '''
+- IV contrast 70-100 ml at right antecubital fossa, flow rate 5 ml/sec
+''',
+      'phaseDesignText': '''
+- Pre-contrast (whole aorta)
+- CTA (whole aorta)
+- Venous (chest and whole abdomen)
+''',
+      'note': '''
+In a patient with suspected Stanford type A aortic dissection, ECG-gated CTA of the ascending thoracic aorta is recommended, followed by CTA of the abdominal aorta.
+'''
+    },
+    // CTA Rupture Aortic Aneurysm
+    "cta_ruptured_aortic_aneu": {
+      'protocolName': idDispMap['cta_ruptured_aortic_aneu']!,
+      'contrastText': '''
+- IV contrast 70-100 ml at right antecubital fossa, flow rate 5 ml/sec
+''',
+      'phaseDesignText': '''
+- Pre-contrast (whole aorta)
+- CTA (whole aorta)
+- Venous (chest and whole abdomen)
+''',
+      'note': null
+    },
+    // CTA for PE
+    "cta_pe": {
+      'protocolName': idDispMap['cta_pe']!,
+      'contrastText': '''
+- IV contrast 60-100 ml at right antecubital fossa, flow rate 5 ml/sec
+''',
+      'phaseDesignText': '''
+- Pre-contrast (chest)
+- CTPA (pulmonary artery)
+- Venous (chest)
+''',
+      'note': null
+    },
+    // CTA Whole Aorta (pre-op TAVR)
+    "cta_tavr_preop": {
+      'protocolName': idDispMap['cta_tavr_preop']!,
+      'contrastText': '''
+- IV contrast 70-100 ml at right antecubital fossa, flow rate 5 ml/sec
+''',
+      'phaseDesignText': '''
+- Pre-contrast: prospective ECG-gated CT covers the heart to evaluate aortic valve calcium scoring
+- ECG-gated CTA covers the ascending aorta to the base of the heart
+- Immediate delay (whole aorta)
+''',
+      'note': null
+    },
+    // CTA Whole Aorta (TEVAR/EVAR)
+    "cta_tevar_evar_follow": {
+      'protocolName': idDispMap['cta_tevar_evar_follow']!,
+      'contrastText': '''
+- IV contrast 70-100 ml at right antecubital fossa, flow rate 5 ml/sec
+''',
+      'phaseDesignText': '''
+- Pre-contrast (whole aorta)
+- CTA (whole aorta)
+- Venous (whole aorta)
+-  Delayed phase 80-120 sec (covers **Only the stent**)
+''',
+      'note': null
+    },
+    // MRA for TRA Stenosis / TRV Thrombosis
+    "mra_tra_ste_trv_thrombo": {
+      'protocolName': idDispMap['mra_tra_ste_trv_thrombo']!,
+      'contrastText': '''
+- IV Gd-based contrast, dose 0.1-0.2 mmol/kg, flow rate 1.5-2.5 ml/sec
+''',
+      'phaseDesignText': '''
+- Ax T1W DIXON (In-phase, oppose phase, fat only, water only)
+- Ax T2W Fast Spin Echo Fat Saturated
+- B-TRANCE
+- Cor contrast-enhanced MRA and MRV
+- Ax and Cor contrast-enhanced T1 fat-sat
+''',
+      'note': null
+    }
+  };
+}

--- a/lib/services/design/design_cvs/design_cvs_protocol_data.dart
+++ b/lib/services/design/design_cvs/design_cvs_protocol_data.dart
@@ -50,9 +50,7 @@ class DesignCvsProtocolData {
     // CTA Coronary (CAD)
     "cta_coro": {
       'protocolName': idDispMap['cta_coro']!,
-      'contrastText': '''
-- IV contrast 50-100 ml at right antecubital fossa, flow rate 5 ml/sec
-''',
+      'contrastText': 'IV contrast 50-100 ml at right antecubital fossa, flow rate 5 ml/sec',
       'phaseDesignText': '''
 - Coronary artery calcium scoring
 - ECG-gated CTA covers the heart
@@ -65,9 +63,7 @@ Patient with CABG -> scan cover from the **thoracic inlet to the base of heart**
     // CTA Cardiac Mass
     "cta_cardiac_mass": {
       'protocolName': idDispMap['cta_cardiac_mass']!,
-      'contrastText': '''
-- IV contrast 60-100 ml at right antecubital fossa, flow rate 5 ml/sec
-''',
+      'contrastText': 'IV contrast 60-100 ml at right antecubital fossa, flow rate 5 ml/sec',
       'phaseDesignText': '''
 - Pre-contrast: prospective ECG-gated CT covers the heart
 - ECG-gated CTA covers the heart
@@ -78,9 +74,7 @@ Patient with CABG -> scan cover from the **thoracic inlet to the base of heart**
     // CTA Aortic Dissection
     "cta_aortic_dissect": {
       'protocolName': idDispMap['cta_aortic_dissect']!,
-      'contrastText': '''
-- IV contrast 70-100 ml at right antecubital fossa, flow rate 5 ml/sec
-''',
+      'contrastText': 'IV contrast 70-100 ml at right antecubital fossa, flow rate 5 ml/sec',
       'phaseDesignText': '''
 - Pre-contrast (whole aorta)
 - CTA (whole aorta)
@@ -93,9 +87,7 @@ In a patient with suspected Stanford type A aortic dissection, ECG-gated CTA of 
     // CTA Rupture Aortic Aneurysm
     "cta_ruptured_aortic_aneu": {
       'protocolName': idDispMap['cta_ruptured_aortic_aneu']!,
-      'contrastText': '''
-- IV contrast 70-100 ml at right antecubital fossa, flow rate 5 ml/sec
-''',
+      'contrastText': 'IV contrast 70-100 ml at right antecubital fossa, flow rate 5 ml/sec',
       'phaseDesignText': '''
 - Pre-contrast (whole aorta)
 - CTA (whole aorta)
@@ -106,9 +98,7 @@ In a patient with suspected Stanford type A aortic dissection, ECG-gated CTA of 
     // CTA for PE
     "cta_pe": {
       'protocolName': idDispMap['cta_pe']!,
-      'contrastText': '''
-- IV contrast 60-100 ml at right antecubital fossa, flow rate 5 ml/sec
-''',
+      'contrastText': 'IV contrast 60-100 ml at right antecubital fossa, flow rate 5 ml/sec',
       'phaseDesignText': '''
 - Pre-contrast (chest)
 - CTPA (pulmonary artery)
@@ -119,9 +109,7 @@ In a patient with suspected Stanford type A aortic dissection, ECG-gated CTA of 
     // CTA Whole Aorta (pre-op TAVR)
     "cta_tavr_preop": {
       'protocolName': idDispMap['cta_tavr_preop']!,
-      'contrastText': '''
-- IV contrast 70-100 ml at right antecubital fossa, flow rate 5 ml/sec
-''',
+      'contrastText': 'IV contrast 70-100 ml at right antecubital fossa, flow rate 5 ml/sec',
       'phaseDesignText': '''
 - Pre-contrast: prospective ECG-gated CT covers the heart to evaluate aortic valve calcium scoring
 - ECG-gated CTA covers the ascending aorta to the base of the heart
@@ -132,9 +120,7 @@ In a patient with suspected Stanford type A aortic dissection, ECG-gated CTA of 
     // CTA Whole Aorta (TEVAR/EVAR)
     "cta_tevar_evar_follow": {
       'protocolName': idDispMap['cta_tevar_evar_follow']!,
-      'contrastText': '''
-- IV contrast 70-100 ml at right antecubital fossa, flow rate 5 ml/sec
-''',
+      'contrastText': 'IV contrast 70-100 ml at right antecubital fossa, flow rate 5 ml/sec',
       'phaseDesignText': '''
 - Pre-contrast (whole aorta)
 - CTA (whole aorta)
@@ -146,9 +132,7 @@ In a patient with suspected Stanford type A aortic dissection, ECG-gated CTA of 
     // MRA for TRA Stenosis / TRV Thrombosis
     "mra_tra_ste_trv_thrombo": {
       'protocolName': idDispMap['mra_tra_ste_trv_thrombo']!,
-      'contrastText': '''
-- IV Gd-based contrast, dose 0.1-0.2 mmol/kg, flow rate 1.5-2.5 ml/sec
-''',
+      'contrastText': 'IV Gd-based contrast, dose 0.1-0.2 mmol/kg, flow rate 1.5-2.5 ml/sec',
       'phaseDesignText': '''
 - Ax T1W DIXON (In-phase, oppose phase, fat only, water only)
 - Ax T2W Fast Spin Echo Fat Saturated

--- a/lib/services/design/design_cvs/template/temp_cvs.mustache
+++ b/lib/services/design/design_cvs/template/temp_cvs.mustache
@@ -2,8 +2,7 @@
 Protocol: {{protocolName}}
 {{/protocolName}}
 {{#contrastText}}
-Contrast: 
-{{contrastText}}
+Contrast: {{contrastText}}
 {{/contrastText}}
 {{#phaseDesignText}}
 Phases:

--- a/lib/services/design/design_cvs/template/temp_cvs.mustache
+++ b/lib/services/design/design_cvs/template/temp_cvs.mustache
@@ -1,0 +1,14 @@
+{{#protocolName}}
+Protocol: {{protocolName}}
+{{/protocolName}}
+{{#contrastText}}
+Contrast: 
+{{contrastText}}
+{{/contrastText}}
+{{#phaseDesignText}}
+Phases:
+{{phaseDesignText}}
+{{/phaseDesignText}}
+{{#note}}
+Note: {{note}}
+{{/note}}

--- a/lib/services/design/design_ward_common/ward_common.dart
+++ b/lib/services/design/design_ward_common/ward_common.dart
@@ -1,0 +1,114 @@
+import '../_utils.dart';
+
+/// The role of the person filling out a ward protocol form.
+///
+/// `label` doubles as the dropdown display text and the output line prefix
+/// (e.g. `Fellow: <name> (Tel: <tel>)`), so changes here propagate to both
+/// the UI and the rendered protocol.
+enum ProtocolAuthor {
+  resident('Resident'),
+  fellow('Fellow'),
+  staff('Staff');
+
+  final String label;
+  const ProtocolAuthor(this.label);
+}
+
+/// Shared "Check ภาพ" + author identification inputs collected on every
+/// Protocol Ward screen (CVS, Chest, Abdomen, MSK, …).
+///
+/// Immutable; the input widget rebuilds a fresh instance on every change and
+/// the screen feeds it into [WardCommon.append] when generating output.
+class WardCommonValues {
+  final bool checkImage;
+  final bool beforeIv;
+  final bool afterIv;
+  final ProtocolAuthor author;
+  final String authorName;
+  final String authorTel;
+
+  const WardCommonValues({
+    required this.checkImage,
+    required this.beforeIv,
+    required this.afterIv,
+    required this.author,
+    required this.authorName,
+    required this.authorTel,
+  });
+
+  /// Default state: nothing ticked, no text filled in, author = Resident
+  /// (the most common case — preserves prior behavior for users who never
+  /// touch the role selector).
+  const WardCommonValues.empty()
+      : checkImage = false,
+        beforeIv = false,
+        afterIv = false,
+        author = ProtocolAuthor.resident,
+        authorName = '',
+        authorTel = '';
+
+  WardCommonValues copyWith({
+    bool? checkImage,
+    bool? beforeIv,
+    bool? afterIv,
+    ProtocolAuthor? author,
+    String? authorName,
+    String? authorTel,
+  }) {
+    return WardCommonValues(
+      checkImage: checkImage ?? this.checkImage,
+      beforeIv: beforeIv ?? this.beforeIv,
+      afterIv: afterIv ?? this.afterIv,
+      author: author ?? this.author,
+      authorName: authorName ?? this.authorName,
+      authorTel: authorTel ?? this.authorTel,
+    );
+  }
+}
+
+/// Renders the trailing block appended to a ward protocol body.
+///
+/// Composed of two independent lines:
+/// - the "Check ภาพ …" line, when `checkImage` is true;
+/// - the author line (`<role>: <name> (Tel: <tel>)`), when `checkImage` is
+///   true OR Name/Tel carries any non-blank text (the author may want to
+///   attach reference info without claiming the image-check action).
+///
+/// Returns an empty string when neither line is needed, so callers can do
+/// `body + (trailer.isEmpty ? '' : '\n$trailer')` without a branch.
+class WardCommon {
+  const WardCommon();
+
+  String append(WardCommonValues v) {
+    final hasAuthorText = v.authorName.trim().isNotEmpty ||
+        v.authorTel.trim().isNotEmpty;
+
+    final parts = <String>[];
+
+    if (v.checkImage) {
+      if (!v.beforeIv && !v.afterIv) {
+        // No phase chosen yet — render just the marker so the line doesn't
+        // dangle a meaningless "... ฉีด IV contrast" suffix.
+        parts.add('Check ภาพ ...');
+      } else {
+        final phase = _phaseToken(beforeIv: v.beforeIv, afterIv: v.afterIv);
+        parts.add('Check ภาพ $phase ฉีด IV contrast');
+      }
+    }
+
+    if (v.checkImage || hasAuthorText) {
+      final name = dashIfBlank(v.authorName);
+      final tel = dashIfBlank(v.authorTel);
+      parts.add('${v.author.label}: $name (Tel: $tel)');
+    }
+
+    return parts.join('\n\n');
+  }
+
+  String _phaseToken({required bool beforeIv, required bool afterIv}) {
+    assert(beforeIv || afterIv,
+        'caller must short-circuit before invoking _phaseToken with neither phase set');
+    if (beforeIv && afterIv) return 'ก่อน + หลัง';
+    return beforeIv ? 'ก่อน' : 'หลัง';
+  }
+}

--- a/lib/services/design/design_ward_common/ward_common.dart
+++ b/lib/services/design/design_ward_common/ward_common.dart
@@ -1,18 +1,7 @@
 import '../_utils.dart';
+import '../enums/protocol_author.dart';
 
-/// The role of the person filling out a ward protocol form.
-///
-/// `label` doubles as the dropdown display text and the output line prefix
-/// (e.g. `Fellow: <name> (Tel: <tel>)`), so changes here propagate to both
-/// the UI and the rendered protocol.
-enum ProtocolAuthor {
-  resident('Resident'),
-  fellow('Fellow'),
-  staff('Staff');
-
-  final String label;
-  const ProtocolAuthor(this.label);
-}
+export '../enums/protocol_author.dart';
 
 /// Shared "Check ภาพ" + author identification inputs collected on every
 /// Protocol Ward screen (CVS, Chest, Abdomen, MSK, …).

--- a/lib/services/design/enums/protocol_author.dart
+++ b/lib/services/design/enums/protocol_author.dart
@@ -1,0 +1,13 @@
+/// The role of the person filling out a ward protocol form.
+///
+/// `label` doubles as the dropdown display text and the output line prefix
+/// (e.g. `Fellow: <name> (Tel: <tel>)`), so changes here propagate to both
+/// the UI and the rendered protocol.
+enum ProtocolAuthor {
+  resident('Resident'),
+  fellow('Fellow'),
+  staff('Staff');
+
+  final String label;
+  const ProtocolAuthor(this.label);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,6 +87,7 @@ flutter:
   # To add assets to your application, add an assets section, like this:
   assets:
     - lib/services/design/designer/template/
+    - lib/services/design/design_cvs/template/
     - lib/services/calculator/templates/
 
   # An image asset can refer to one or more resolution-specific "variants", see


### PR DESCRIPTION
## Summary

- **Protocol CVS** (`/design/ward/cvs`) — new cardiovascular CTA/MRA generator with 2-level Exam → Protocol selector. Service in `lib/services/design/design_cvs/`, mustache template + 9 protocols (CT calcium, CTA coronary, cardiac mass, aortic dissection, ruptured aneurysm, PE, pre-op TAVR, TEVAR/EVAR follow-up, MRA TRA/TRV).
- **Protocol Ward gallery** (`/design/ward`) — body-part protocol hub. CVS is active; Chest / Abdomen / MSK rendered as disabled "Soon" stubs ready for future protocols.
- **Reusable ward-common trailer** — every Protocol Ward screen now shares a `Check ภาพ` block (gating `ก่อน` / `หลัง IV contrast` sub-checkboxes) plus a `Role` dropdown (`ProtocolAuthor`: Resident / Fellow / Staff) + Name + Tel. Pressing Enter in Name/Tel submits Generate. Service: `WardCommon`; widget: `WardCommonInput`. Future ward screens consume both with ~2 lines of wiring.
- **`TwoLevelDropdowns`** widget for the simpler 2-level cascades — sibling of the existing `ThreeLevelDropdowns`.
- **`ProtocolAuthor` enum** extracted to `lib/services/design/enums/` and re-exported from `ward_common.dart`, so future design services can depend on the role enum without dragging in the ward-common trailer logic.
- **Manual fix (3adec0c):** tightens contrast text formatting in existing protocol templates.
- **`devtools_options.yaml` ignored** to keep per-developer DevTools UI preferences out of git.
- **`CLAUDE.md` refactor** — feature-area sections, single routes table, conventions hoisted out of per-feature notes.

## Test plan

- [ ] \`fvm flutter analyze\` is clean.
- [ ] Home page shows the new **Protocol Ward** card; clicking it opens the gallery.
- [ ] Gallery shows 4 cards; only **Protocol CVS** is clickable.
- [ ] Drawer → Design Study expansion shows Protocol ER / Protocol Ward / Protocol CVS; each navigates and highlights correctly.
- [ ] \`/design/ward/cvs\`: pick \`CT → CTA Coronary (CAD)\` and Generate — protocol body renders.
- [ ] \`CT → CTA Whole Aorta (TEVAR/EVAR)\` resolves (verifies the previously-unreachable entry).
- [ ] \`MRI → MRA for TRA Stenosis / TRV Thrombosis\` resolves (covers the MRI branch).
- [ ] Tick **Check ภาพ** alone → trailer shows \`Check ภาพ ...\` only (no \`ฉีด IV contrast\` suffix).
- [ ] Tick Check ภาพ + ก่อน → \`Check ภาพ ก่อน ฉีด IV contrast\`; + หลัง → \`หลัง\`; + both → \`ก่อน + หลัง\`.
- [ ] Untick Check ภาพ but fill Name → role-prefixed Resident/Fellow/Staff line renders alone.
- [ ] Role dropdown swaps the prefix (Resident / Fellow / Staff).
- [ ] Pressing Enter in Name or Tel triggers Generate (when a protocol is selected).
- [ ] Reset clears every input + the output box.
- [ ] Resize browser below 800px → layout switches to stacked.
- [ ] Copy button copies the generated text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)